### PR TITLE
Improve usability

### DIFF
--- a/lua/cfc_vote/server/vote.lua
+++ b/lua/cfc_vote/server/vote.lua
@@ -176,7 +176,7 @@ end
 function CFC_Vote.tryVote( ply, fromConsole, args )
     if not IsValid( ply ) then return end
 
-    if ULib and not ULib.ucl.query( ply, "ulx vote", true ) then
+    if ULib and not ULib.ucl.query( ply, "ulx cfcvote", true ) then
         if fromConsole then
             net.Start( CFC_Vote.NET_CONSOLE_PRINT )
             net.WriteString( "You do not have access to this command, " .. ply:Nick() .. "." )

--- a/lua/cfc_vote/server/vote.lua
+++ b/lua/cfc_vote/server/vote.lua
@@ -56,7 +56,7 @@ local function doVote( caller, args, optionCount )
             isVoteAdmin = ply:IsAdmin()
         end
 
-        if isVoteAdmin then
+        if isVoteAdmin and ply ~= caller then
             table.insert( adminPlys, ply )
         end
     end
@@ -76,10 +76,14 @@ local function doVote( caller, args, optionCount )
     resultNotif:SetTitle( "CFC Vote Results" )
     adminNotif:SetTitle( "CFC Vote Admin Info" )
 
+    liveNotif:AddButtonAligned( "Stop the vote", CFC_Vote.BUTTON_STOP_COLOR, CFCNotifications.ALIGN_CENTER )
+    liveNotif:NewButtonRow()
+
     for index, option in pairs( args ) do
         voteResults[index] = 0
         notif:AddButtonAligned( option, CFC_Vote.BUTTON_VOTE_COLOR, CFCNotifications.ALIGN_LEFT, index )
         liveNotif:AddButtonAligned( option .. "\n0", CFC_Vote.BUTTON_VOTE_COLOR, CFCNotifications.ALIGN_LEFT )
+        liveNotif:EditButtonCanPress( index + 1, 1, false )
         liveNotif:NewButtonRow()
 
         if index < optionCount then
@@ -89,12 +93,13 @@ local function doVote( caller, args, optionCount )
 
     voteResults[optionCount + 1] = #voters
     liveNotif:AddButtonAligned( "No Response\n" .. voteResults[optionCount + 1], Color( 255, 0, 0, 255 ), CFCNotifications.ALIGN_LEFT )
+    liveNotif:EditButtonCanPress( optionCount + 2, 1, false )
 
     adminNotif:AddButtonAligned( "Stop the vote", CFC_Vote.BUTTON_STOP_COLOR, CFCNotifications.ALIGN_CENTER, true )
     adminNotif:AddButtonAligned( "Discard this", CFC_Vote.BUTTON_DISCARD_COLOR, CFCNotifications.ALIGN_CENTER, false )
 
     setNotifSettings( notif, question .. "\n\nClick on a button below to vote!" )
-    setNotifSettings( liveNotif, question .. "\n\nThese are the live results!\nClick on any button to stop the vote early." )
+    setNotifSettings( liveNotif, question .. "\n\nThese are the live results!" )
     setNotifSettings( resultNotif, question .. "\n\nThese are the results!\nClick on any button to close this message." )
     setNotifSettings( adminNotif, "The current vote was created by\n" .. caller:Nick() .. " " .. caller:SteamID() )
 
@@ -109,8 +114,8 @@ local function doVote( caller, args, optionCount )
         local optionResultText = args[index] .. "\n" .. voteResults[index]
         local UndecidedText = "No Response\n" .. voteResults[optionCount + 1]
 
-        liveNotif:EditButtonText( index, 1, optionResultText, CFC_Vote.voteCaller )
-        liveNotif:EditButtonText( optionCount + 1, 1, UndecidedText, CFC_Vote.voteCaller )
+        liveNotif:EditButtonText( index + 1, 1, optionResultText, CFC_Vote.voteCaller )
+        liveNotif:EditButtonText( optionCount + 2, 1, UndecidedText, CFC_Vote.voteCaller )
     end
 
     function liveNotif:OnButtonPressed( ply )

--- a/lua/cfc_vote/server/vote.lua
+++ b/lua/cfc_vote/server/vote.lua
@@ -47,7 +47,7 @@ local function doVote( caller, args, optionCount )
     table.RemoveByValue( voters, caller )
     table.remove( args, 1 )
 
-    for i, ply in pairs( plys ) do
+    for i, ply in ipairs( plys ) do
         local isVoteAdmin
 
         if ULib then
@@ -79,7 +79,7 @@ local function doVote( caller, args, optionCount )
     liveNotif:AddButtonAligned( "Stop the vote", CFC_Vote.BUTTON_STOP_COLOR, CFCNotifications.ALIGN_CENTER )
     liveNotif:NewButtonRow()
 
-    for index, option in pairs( args ) do
+    for index, option in ipairs( args ) do
         voteResults[index] = 0
         notif:AddButtonAligned( option, CFC_Vote.BUTTON_VOTE_COLOR, CFCNotifications.ALIGN_LEFT, index )
         liveNotif:AddButtonAligned( option .. "\n0", CFC_Vote.BUTTON_VOTE_COLOR, CFCNotifications.ALIGN_LEFT )
@@ -118,7 +118,7 @@ local function doVote( caller, args, optionCount )
         liveNotif:EditButtonText( optionCount + 2, 1, UndecidedText, CFC_Vote.voteCaller )
     end
 
-    function liveNotif:OnButtonPressed( ply )
+    function liveNotif:OnButtonPressed()
         CFC_Vote.stopVote()
     end
 
@@ -126,7 +126,7 @@ local function doVote( caller, args, optionCount )
         resultNotif:RemovePopup( resultNotif:GetCallingPopupID(), ply )
     end
 
-    function adminNotif:OnButtonPressed( ply, stop )
+    function adminNotif:OnButtonPressed( _, stop )
         if not stop then return end
 
         CFC_Vote.stopVote( true )
@@ -153,7 +153,7 @@ local function doVote( caller, args, optionCount )
             end
         end
 
-        for index, option in pairs( args ) do
+        for index, option in ipairs( args ) do
             local color = CFC_Vote.BUTTON_VOTE_COLOR
 
             if highInds[index] then
@@ -240,7 +240,7 @@ function CFC_Vote.tryVote( ply, fromConsole, args )
         ply:ChatPrint( "Creating a vote..." )
     end
 
-    for index, option in pairs( args ) do
+    for index, option in ipairs( args ) do
         if index > 1 then
             args[index] = string.Replace( option, "\n", "" )
         end
@@ -279,7 +279,7 @@ local function voteFromULX( caller, title, ... )
     local args = { ... }
     local maxOptions = CFC_Vote.VOTE_MAX_OPTIONS:GetInt()
 
-    for index, option in pairs( args ) do
+    for index, option in ipairs( args ) do
         if index > maxOptions then
             args[index] = nil
         else

--- a/lua/cfc_vote/shared/base.lua
+++ b/lua/cfc_vote/shared/base.lua
@@ -16,7 +16,10 @@ CFC_Vote.VOTE_DURATION = CreateConVar( "cfc_vote_duration", 30, FCVAR_NONE, "How
 CFC_Vote.RESULTS_DURATION = CreateConVar( "cfc_vote_results_duration", 15, FCVAR_NONE, "How long vote results will last for, in seconds", 1, 50000 )
 CFC_Vote.NOTIFICATION_VOTE_NAME = "CFC_Vote_VoteQuery"
 CFC_Vote.NOTIFICATION_RESULTS_NAME = "CFC_Vote_VoteResults"
+CFC_Vote.NOTIFICATION_ADMIN_NAME = "CFC_Vote_AdminInfo"
 CFC_Vote.NOTIFICATION_STOP_NAME = "CFC_Vote_VoteStop"
-CFC_Vote.BUTTON_COLOR = Color( 200, 220, 245, 255 )
+CFC_Vote.BUTTON_VOTE_COLOR = Color( 200, 220, 245, 255 )
+CFC_Vote.BUTTON_STOP_COLOR = Color( 230, 58, 64, 255 )
+CFC_Vote.BUTTON_DISCARD_COLOR = Color( 230, 153, 58, 255 )
 
 include( "cfc_vote/server/vote.lua" )

--- a/lua/cfc_vote/shared/base.lua
+++ b/lua/cfc_vote/shared/base.lua
@@ -5,6 +5,15 @@ CFC_Vote.NOTIFICATION_LIVE_NAME = "CFC_Vote_VoteLive"
 
 if CLIENT then
     include( "cfc_vote/client/net.lua" )
+
+    if not ulx then return end
+
+    local voteCmd = ulx.command( "Voting", "ulx cfcvote", function() end )
+    voteCmd:addParam{ type=ULib.cmds.StringArg, hint="title" }
+    voteCmd:addParam{ type=ULib.cmds.StringArg, hint="options", ULib.cmds.takeRestOfLine, repeat_min=2, repeat_max=10 }
+    voteCmd:defaultAccess( ULib.ACCESS_ADMIN )
+    voteCmd:help( "Starts a fancy public vote." )
+    
     return
 end
 


### PR DESCRIPTION
This will show staff members (players who have access to ulx stopvote, or who return true with :IsAdmin() if ulx does not exist) the name and Steam ID of the player who created the vote, and it allows them to stop the vote early.

Additionally, this will make the live results notification more clear by disabling the ability to click on the result buttons and adding a new button labeled "Stop the vote."

Finally, this adds a ulx command for creating CFC Votes, allowing players to create votes from an easily-accessible, familiar GUI.

The second feature of this PR requires the :EditButtonCanPress() function introduced in [this CFC Notifications PR](https://github.com/CFC-Servers/cfc_notifications/pull/19)